### PR TITLE
テストでの修正と足りない機能の実装完了

### DIFF
--- a/lib/feed_page.dart
+++ b/lib/feed_page.dart
@@ -1,6 +1,6 @@
-import 'package:custom_refresh_indicator/custom_refresh_indicator.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:mobile_qiita_application/constants.dart';
 import 'package:mobile_qiita_application/error_page.dart';
 import 'item_list.dart';
 import 'models/item.dart';
@@ -14,7 +14,7 @@ class FeedPage extends StatefulWidget {
 
 class _FeedPageState extends State<FeedPage> {
   QiitaRepository repository = QiitaRepository();
-  String onChangedText = '';
+  String onFieldSubmittedText = '';
   final textController = TextEditingController();
   int _page = 1;
   List<Item> itemList = [];
@@ -22,7 +22,7 @@ class _FeedPageState extends State<FeedPage> {
 
   @override
   void initState() {
-    refreshItem = QiitaRepository.fetchItems(_page, onChangedText);
+    refreshItem = QiitaRepository.fetchItems(_page, onFieldSubmittedText);
     super.initState();
   }
 
@@ -34,8 +34,10 @@ class _FeedPageState extends State<FeedPage> {
           controller: textController,
           decoration: InputDecoration(
             hintText: 'Search',
-            prefixIcon: Icon(Icons.search,
-              size: 25,),
+            prefixIcon: Icon(
+              Icons.search,
+              size: 25,
+            ),
             isDense: true,
             contentPadding: EdgeInsets.fromLTRB(40, 0, 0, 0),
             hintStyle: TextStyle(color: Color(0xFF848484), fontSize: 17),
@@ -54,137 +56,126 @@ class _FeedPageState extends State<FeedPage> {
               borderSide: BorderSide(color: Colors.redAccent, width: 1),
             ),
           ),
-          onChanged: (value) {
-            print('onchanged: $value');
+          onFieldSubmitted: (value) {
+            print('onFieldSubmittedText: $value');
             setState(() {
-              onChangedText = value;
-              QiitaRepository.fetchItems(_page, onChangedText);
+              onFieldSubmittedText = value;
+              refreshItem =
+                  QiitaRepository.fetchItems(_page, onFieldSubmittedText);
             });
-            }
-      ),
+          }),
     );
   }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-        appBar: AppBar(
-          shadowColor: Colors.black38,
-          backgroundColor: Colors.white,
-          title: Text('Feed',
-            style: TextStyle(
-              fontSize: 17,
-              fontFamily: 'Pacifico',
-              color: Colors.black,
+    return GestureDetector(
+        onPanDown: (_) => FocusScope.of(context).requestFocus(FocusNode()),
+        child: Scaffold(
+          appBar: AppBar(
+            elevation: 0,
+            shadowColor: Colors.black38,
+            backgroundColor: Colors.white,
+            title: Text(
+              'Feed',
+              style: TextStyle(
+                fontSize: 17,
+                fontFamily: 'Pacifico',
+                color: Colors.black,
+              ),
+            ),
+            centerTitle: true,
+            bottom: PreferredSize(
+              preferredSize: const Size.fromHeight(40),
+              child: Column(
+                children: [
+                  Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+                    child: _textField(),
+                  ),
+                  Divider(
+                    height: 0,
+                    thickness: 0.5,
+                    color: Constants.greyDivider,
+                  )
+                ],
+              ),
             ),
           ),
-          centerTitle: true,
-          bottom: PreferredSize(
-            preferredSize: const Size.fromHeight(40),
-            child: Padding(
-              padding: EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-              child: _textField(),
-            ),
-          ),
-        ),
-        body: Center(
-          child: Column(
-            children: [
-              FutureBuilder<List<Item>>(
-                  future: refreshItem,
-                  builder: (BuildContext context,
-                      AsyncSnapshot<List<Item>> snapshot) {
-                    if (snapshot.connectionState == ConnectionState.waiting) {
-                      return Expanded(
-                          child: Center(
-                            child: CircularProgressIndicator(),
-                          ),
-                      );
+          body: Center(
+            child: FutureBuilder<List<Item>>(
+                future: refreshItem,
+                builder:
+                    (BuildContext context, AsyncSnapshot<List<Item>> snapshot) {
+                  if (snapshot.connectionState == ConnectionState.waiting) {
+                    return Expanded(
+                      child: Center(
+                        child: CircularProgressIndicator(),
+                      ),
+                    );
+                  }
+                  try {
+                    if (snapshot.hasData) {
+                      if (snapshot.data!.length == 0) {
+                        return searchErrorPage();
+                      } else {
+                        return RefreshIndicator(
+                            child: ItemList(
+                                items: snapshot.data!,
+                                onFieldSubmittedText: onFieldSubmittedText),
+                            onRefresh: () async {
+                              setState(() {
+                                refreshItem = QiitaRepository.fetchItems(
+                                    _page, onFieldSubmittedText);
+                              });
+                            });
+                      }
                     }
-                     else if (snapshot.hasError) {
-                      return ErrorPage(
-                        refreshFunction: () {
-                          refreshItem = QiitaRepository.fetchItems(_page, onChangedText);
-                        },
-                      );
-                    } else {
-                      return Expanded(
-                          child: CustomRefreshIndicator(
-                              onRefresh: () async {
-                                await Future.delayed(const Duration(seconds: 3));
-                                fetchRefresh();
-                              },
-                              child: ItemList(items: snapshot.data!),
-                              builder: (
-                              BuildContext context,
-                              Widget child,
-                              IndicatorController controller,
-                              ) {
-                                return AnimatedBuilder(
-                                    animation: controller,
-                                    builder: (BuildContext context, _) {
-                                      return Stack(
-                                        alignment: Alignment.topCenter,
-                                        children: [
-                                          if(!controller.isIdle)
-                                            Positioned(
-                                              top: 35.0 * controller.value,
-                                                child: SizedBox(
-                                                  height: 30,
-                                                  width: 30,
-                                                  child: CircularProgressIndicator(
-                                                    value: !controller.isLoading
-                                                        ? controller.value.clamp(0.0, 1.0)
-                                                        : null,
-                                                  ),
-                                                ),
-                                            ),
-                                          Transform.translate(
-                                            offset: Offset(0, 100.0 * controller.value),
-                                            child: child,
-                                          )
-                                        ],
-                                      );
-                                    });
-                              },
-                          ));
-                    }
-                  }),
-            ],
+                  } catch (exception) {
+                    return ErrorPage(
+                      refreshFunction: () {
+                        refreshItem = QiitaRepository.fetchItems(
+                            _page, onFieldSubmittedText);
+                      },
+                    );
+                  }
+                  if (snapshot.hasError) {
+                    return ErrorPage(refreshFunction: () {
+                      refreshItem = QiitaRepository.fetchItems(
+                          _page, onFieldSubmittedText);
+                    });
+                  } else {
+                    return Text('データーがありません');
+                  }
+                }),
           ),
-        )
-    );
+        ));
   }
 
-  fetchRefresh() async {
-    await Future.delayed(const Duration(seconds: 1));
-    _page = 1;
-    var items = await QiitaRepository.fetchItems(_page, onChangedText);
-    print(items);
-    setState(() {
-      itemList.addAll(items);
-    });
-  }
-  searchErrorPage() {
-    Column(
+  Widget searchErrorPage() {
+    return Column(
       children: [
+        Expanded(child: Container()),
         Center(
-          child: Text('検索にマッチする記事はありませんでした',
-          style: TextStyle(
-            color: Color(0xFF333333),
-            fontSize: 14,
-          ),
+          child: Text(
+            '検索にマッチする記事はありませんでした',
+            style: TextStyle(
+              color: Color(0xFF333333),
+              fontSize: 14,
+            ),
           ),
         ),
         SizedBox(height: 20),
         Center(
-          child: Text('検索条件を変えるなどして再度検索をしてください',
-          style: TextStyle(
-            color: Color(0xFF828282),
-            fontSize: 12,
+          child: Text(
+            '検索条件を変えるなどして再度検索をしてください',
+            style: TextStyle(
+              color: Color(0xFF828282),
+              fontSize: 12,
+            ),
           ),
-          ),
-        )
+        ),
+        Expanded(child: Container()),
       ],
     );
   }

--- a/lib/feed_page.dart
+++ b/lib/feed_page.dart
@@ -108,44 +108,29 @@ class _FeedPageState extends State<FeedPage> {
                 builder:
                     (BuildContext context, AsyncSnapshot<List<Item>> snapshot) {
                   if (snapshot.connectionState == ConnectionState.waiting) {
-                    return Expanded(
-                      child: Center(
-                        child: CircularProgressIndicator(),
-                      ),
-                    );
-                  }
-                  try {
-                    if (snapshot.hasData) {
-                      if (snapshot.data!.length == 0) {
-                        return searchErrorPage();
-                      } else {
-                        return RefreshIndicator(
-                            child: ItemList(
-                                items: snapshot.data!,
-                                onFieldSubmittedText: onFieldSubmittedText),
-                            onRefresh: () async {
-                              setState(() {
-                                refreshItem = QiitaRepository.fetchItems(
-                                    _page, onFieldSubmittedText);
-                              });
-                            });
-                      }
-                    }
-                  } catch (exception) {
-                    return ErrorPage(
-                      refreshFunction: () {
-                        refreshItem = QiitaRepository.fetchItems(
-                            _page, onFieldSubmittedText);
-                      },
-                    );
+                    return CircularProgressIndicator();
                   }
                   if (snapshot.hasError) {
                     return ErrorPage(refreshFunction: () {
                       refreshItem = QiitaRepository.fetchItems(
                           _page, onFieldSubmittedText);
                     });
+                  }
+                  if (snapshot.hasData && snapshot.data!.isNotEmpty) {
+                    return RefreshIndicator(
+                        child: ItemList(
+                            items: snapshot.data!,
+                            onFieldSubmittedText: onFieldSubmittedText),
+                        onRefresh: () async {
+                          setState(() {
+                            refreshItem = QiitaRepository.fetchItems(
+                                _page, onFieldSubmittedText);
+                          });
+                        });
                   } else {
-                    return Text('データーがありません');
+                    return onFieldSubmittedText.isNotEmpty
+                        ? searchErrorPage()
+                        : Text('データが存在しません');
                   }
                 }),
           ),

--- a/lib/feed_page.dart
+++ b/lib/feed_page.dart
@@ -97,7 +97,7 @@ class _FeedPageState extends State<FeedPage> {
                     height: 0,
                     thickness: 0.5,
                     color: Constants.greyDivider,
-                  )
+                  ),
                 ],
               ),
             ),

--- a/lib/follow_follower_page.dart
+++ b/lib/follow_follower_page.dart
@@ -6,7 +6,7 @@ import 'package:mobile_qiita_application/follows_page.dart';
 import 'package:mobile_qiita_application/models/user.dart';
 
 class FollowFollowerPage extends StatefulWidget {
-  bool followeesTapped;
+  bool? followeesTapped;
   final User userData;
   FollowFollowerPage(
       {Key? key, required this.userData, required this.followeesTapped})
@@ -78,7 +78,7 @@ class _FollowFollowersPageState extends State<FollowFollowerPage> {
                     onValueChanged: (switchValue) {
                       print(switchValue);
                       setState(() {
-                        widget.followeesTapped = switchValue!;
+                        widget.followeesTapped = switchValue;
                       });
                     },
                   ),

--- a/lib/follow_follower_page.dart
+++ b/lib/follow_follower_page.dart
@@ -86,13 +86,9 @@ class _FollowFollowersPageState extends State<FollowFollowerPage> {
               ],
             ),
           ),
-          (() {
-            if (widget.followeesTapped == true) {
-              return FollowsPage(userData: widget.userData);
-            } else {
-              return FollowersPage(userData: widget.userData);
-            }
-          })(),
+          (widget.followeesTapped == true)
+              ? FollowsPage(userData: widget.userData)
+              : FollowersPage(userData: widget.userData),
         ],
       ),
     );

--- a/lib/follow_follower_page.dart
+++ b/lib/follow_follower_page.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:mobile_qiita_application/constants.dart';
+import 'package:mobile_qiita_application/followers_page.dart';
+import 'package:mobile_qiita_application/follows_page.dart';
+import 'package:mobile_qiita_application/models/user.dart';
+
+class FollowFollowerPage extends StatefulWidget {
+  bool followeesTapped;
+  final User userData;
+  FollowFollowerPage(
+      {Key? key, required this.userData, required this.followeesTapped})
+      : super(key: key);
+  @override
+  _FollowFollowersPageState createState() => _FollowFollowersPageState();
+}
+
+class _FollowFollowersPageState extends State<FollowFollowerPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        automaticallyImplyLeading: false,
+        backgroundColor: Constants.white,
+        elevation: 0,
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back_ios_outlined,
+              color: Constants.primaryColor),
+          onPressed: () {
+            Navigator.pop(context);
+          },
+        ),
+        title: Text(
+          widget.userData.name.isNotEmpty
+              ? widget.userData.name
+              : widget.userData.id,
+          style: TextStyle(
+            color: Constants.black,
+            fontSize: 15,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        centerTitle: true,
+        bottom: PreferredSize(
+          preferredSize: Size.fromHeight(0),
+          child: Divider(
+            height: 0,
+            thickness: 0.5,
+            color: Constants.greyDivider,
+          ),
+        ),
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+            child: Row(
+              children: [
+                Expanded(
+                  child: CupertinoSlidingSegmentedControl<bool>(
+                    groupValue: widget.followeesTapped,
+                    children: {
+                      true: Text(
+                        'フォロー中',
+                        style: TextStyle(
+                          fontWeight: FontWeight.w600,
+                          color: Constants.black,
+                        ),
+                      ),
+                      false: Text(
+                        'フォロワー',
+                        style: TextStyle(
+                          fontWeight: FontWeight.w600,
+                          color: Constants.black,
+                        ),
+                      )
+                    },
+                    onValueChanged: (switchValue) {
+                      print(switchValue);
+                      setState(() {
+                        widget.followeesTapped = switchValue!;
+                      });
+                    },
+                  ),
+                )
+              ],
+            ),
+          ),
+          (() {
+            if (widget.followeesTapped == true) {
+              return FollowsPage(userData: widget.userData);
+            } else {
+              return FollowersPage(userData: widget.userData);
+            }
+          })(),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/followees_list.dart
+++ b/lib/followees_list.dart
@@ -34,6 +34,7 @@ class _FolloweesListState extends State<FolloweesList> {
   @override
   Widget build(BuildContext context) {
     return ListView.builder(
+        shrinkWrap: true,
         controller: _scrollController,
         itemCount: widget.userList.length,
         itemBuilder: (BuildContext context, int index) {
@@ -45,78 +46,81 @@ class _FolloweesListState extends State<FolloweesList> {
                   border: Border.all(color: Constants.greyBorder, width: 1),
                   borderRadius: BorderRadius.circular(8),
                 ),
-                child: InkWell(
-                  onTap: () {
-                    Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                            builder: (_) =>
-                                UserPage(userData: widget.userList[index])));
-                  },
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        children: [
-                          Container(
-                            margin: EdgeInsets.only(left: 16, top: 8),
-                            child: CircleAvatar(
-                              backgroundImage: NetworkImage(
-                                  widget.userList[index].profileImageUrl),
-                              radius: 19,
+                child: Material(
+                  clipBehavior: Clip.antiAlias,
+                  child: InkWell(
+                    onTap: () {
+                      Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                              builder: (_) =>
+                                  UserPage(userData: widget.userList[index])));
+                    },
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Container(
+                              margin: EdgeInsets.only(left: 16, top: 8),
+                              child: CircleAvatar(
+                                backgroundImage: NetworkImage(
+                                    widget.userList[index].profileImageUrl),
+                                radius: 19,
+                              ),
+                            ),
+                            SizedBox(width: 10),
+                            Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  widget.userList[index].name.isNotEmpty
+                                      ? widget.userList[index].name
+                                      : widget.userList[index].id,
+                                  style: TextStyle(
+                                    fontSize: 14,
+                                    letterSpacing: 0.25,
+                                    color: Constants.black,
+                                  ),
+                                ),
+                                SizedBox(height: 3),
+                                Text(
+                                  '@${widget.userList[index].id}',
+                                  style: TextStyle(
+                                    fontSize: 12,
+                                    color: Constants.grey,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                        SizedBox(height: 8),
+                        Container(
+                          margin: EdgeInsets.only(left: 16),
+                          child: Text(
+                            'Posts: ${widget.userList[index].itemsCount}',
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: Constants.black,
                             ),
                           ),
-                          SizedBox(width: 10),
-                          Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                widget.userList[index].name.isNotEmpty
-                                    ? widget.userList[index].name
-                                    : widget.userList[index].id,
-                                style: TextStyle(
-                                  fontSize: 14,
-                                  letterSpacing: 0.25,
-                                  color: Constants.black,
-                                ),
-                              ),
-                              SizedBox(height: 3),
-                              Text(
-                                '@${widget.userList[index].id}',
-                                style: TextStyle(
-                                  fontSize: 12,
-                                  color: Constants.grey,
-                                ),
-                              ),
-                            ],
-                          ),
-                        ],
-                      ),
-                      SizedBox(height: 8),
-                      Container(
-                        margin: EdgeInsets.only(left: 16),
-                        child: Text(
-                          'Posts: ${widget.userList[index].itemsCount}',
-                          style: TextStyle(
-                            fontSize: 12,
-                            color: Constants.black,
-                          ),
                         ),
-                      ),
-                      SizedBox(height: 8),
-                      Container(
-                        margin: EdgeInsets.only(bottom: 8, left: 16),
-                        child: Text(
-                          widget.userList[index].description != null
-                              ? widget.userList[index].description!
-                              : "",
-                          style: TextStyle(
-                              fontSize: 12,
-                              letterSpacing: 0.25,
-                              color: Constants.grey),
-                        ),
-                      )
-                    ],
+                        SizedBox(height: 8),
+                        Container(
+                          margin: EdgeInsets.only(bottom: 8, left: 16),
+                          child: Text(
+                            widget.userList[index].description != null
+                                ? widget.userList[index].description!
+                                : "",
+                            style: TextStyle(
+                                fontSize: 12,
+                                letterSpacing: 0.25,
+                                color: Constants.grey),
+                          ),
+                        )
+                      ],
+                    ),
                   ),
                 ),
               ),

--- a/lib/followers_list.dart
+++ b/lib/followers_list.dart
@@ -33,6 +33,7 @@ class _FollowersListState extends State<FollowersList> {
   @override
   Widget build(BuildContext context) {
     return ListView.builder(
+        shrinkWrap: true,
         controller: _scrollController,
         itemCount: widget.followersList.length,
         itemBuilder: (BuildContext context, int index) {

--- a/lib/followers_page.dart
+++ b/lib/followers_page.dart
@@ -21,10 +21,8 @@ class _FollowersPageState extends State<FollowersPage> {
         future: QiitaRepository.fetchFollowers(widget.userData.id, _page),
         builder: (BuildContext context, AsyncSnapshot<List<User>> snapshot) {
           if (snapshot.connectionState == ConnectionState.waiting) {
-            return Expanded(
-              child: Center(
-                child: CircularProgressIndicator(),
-              ),
+            return Center(
+              child: CircularProgressIndicator(),
             );
           } else if (snapshot.hasError) {
             return ErrorPage(refreshFunction: () {

--- a/lib/followers_page.dart
+++ b/lib/followers_page.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:mobile_qiita_application/constants.dart';
 import 'package:mobile_qiita_application/error_page.dart';
 import 'package:mobile_qiita_application/followers_list.dart';
 import 'package:mobile_qiita_application/models/user.dart';
@@ -17,49 +16,25 @@ class _FollowersPageState extends State<FollowersPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        automaticallyImplyLeading: false,
-        backgroundColor: Constants.white,
-        elevation: 1,
-        leading: IconButton(
-          icon: Icon(Icons.arrow_back_ios_outlined,
-              color: Constants.primaryColor),
-          onPressed: () {
-            Navigator.pop(context);
-          },
-        ),
-        title: Text(
-          widget.userData.name.isNotEmpty
-              ? widget.userData.name
-              : widget.userData.id,
-          style: TextStyle(
-              fontSize: 17,
-              fontWeight: FontWeight.w600,
-              color: Constants.primary),
-        ),
-        centerTitle: true,
-      ),
-      body: Center(
-        child: FutureBuilder<List<User>>(
-          future: QiitaRepository.fetchFollowers(widget.userData.id, _page),
-          builder: (BuildContext context, AsyncSnapshot<List<User>> snapshot) {
-            if (snapshot.connectionState == ConnectionState.waiting) {
-              return Expanded(
-                child: Center(
-                  child: CircularProgressIndicator(),
-                ),
-              );
-            } else if (snapshot.hasError) {
-              return ErrorPage(refreshFunction: () {
-                QiitaRepository.fetchFollowers(widget.userData.id, _page);
-              });
-            } else {
-              return FollowersList(
-                  followersList: snapshot.data!, userData: widget.userData);
-            }
-          },
-        ),
+    return Expanded(
+      child: FutureBuilder<List<User>>(
+        future: QiitaRepository.fetchFollowers(widget.userData.id, _page),
+        builder: (BuildContext context, AsyncSnapshot<List<User>> snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return Expanded(
+              child: Center(
+                child: CircularProgressIndicator(),
+              ),
+            );
+          } else if (snapshot.hasError) {
+            return ErrorPage(refreshFunction: () {
+              QiitaRepository.fetchFollowers(widget.userData.id, _page);
+            });
+          } else {
+            return FollowersList(
+                followersList: snapshot.data!, userData: widget.userData);
+          }
+        },
       ),
     );
   }

--- a/lib/follows_page.dart
+++ b/lib/follows_page.dart
@@ -3,7 +3,6 @@ import 'package:mobile_qiita_application/error_page.dart';
 import 'package:mobile_qiita_application/followees_list.dart';
 import 'package:mobile_qiita_application/models/user.dart';
 import 'package:mobile_qiita_application/qiita_repository.dart';
-import 'constants.dart';
 
 class FollowsPage extends StatefulWidget {
   final User userData;
@@ -17,57 +16,25 @@ class _FollowsPageState extends State<FollowsPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        automaticallyImplyLeading: false,
-        backgroundColor: Constants.white,
-        elevation: 0,
-        leading: IconButton(
-          icon: Icon(Icons.arrow_back_ios_outlined,
-              color: Constants.primaryColor),
-          onPressed: () {
-            Navigator.pop(context);
-          },
-        ),
-        title: Text(
-          widget.userData.name.isNotEmpty
-              ? widget.userData.name
-              : widget.userData.id,
-          style: TextStyle(
-              fontSize: 17,
-              fontWeight: FontWeight.w600,
-              color: Constants.primary),
-        ),
-        centerTitle: true,
-        bottom: PreferredSize(
-          preferredSize: Size.fromHeight(0),
-          child: Divider(
-            height: 0,
-            thickness: 0.5,
-            color: Constants.greyDivider,
-          ),
-        ),
-      ),
-      body: Center(
-        child: FutureBuilder<List<User>>(
-          future: QiitaRepository.fetchFollowees(widget.userData.id, _page),
-          builder: (BuildContext context, AsyncSnapshot<List<User>> snapshot) {
-            if (snapshot.connectionState == ConnectionState.waiting) {
-              return Expanded(
-                child: Center(
-                  child: CircularProgressIndicator(),
-                ),
-              );
-            } else if (snapshot.hasError) {
-              return ErrorPage(refreshFunction: () {
-                QiitaRepository.fetchFollowees(widget.userData.id, _page);
-              });
-            } else {
-              return FolloweesList(
-                  userList: snapshot.data!, userData: widget.userData);
-            }
-          },
-        ),
+    return Expanded(
+      child: FutureBuilder<List<User>>(
+        future: QiitaRepository.fetchFollowees(widget.userData.id, _page),
+        builder: (BuildContext context, AsyncSnapshot<List<User>> snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return Expanded(
+              child: Center(
+                child: CircularProgressIndicator(),
+              ),
+            );
+          } else if (snapshot.hasError) {
+            return ErrorPage(refreshFunction: () {
+              QiitaRepository.fetchFollowees(widget.userData.id, _page);
+            });
+          } else {
+            return FolloweesList(
+                userList: snapshot.data!, userData: widget.userData);
+          }
+        },
       ),
     );
   }

--- a/lib/follows_page.dart
+++ b/lib/follows_page.dart
@@ -21,10 +21,8 @@ class _FollowsPageState extends State<FollowsPage> {
         future: QiitaRepository.fetchFollowees(widget.userData.id, _page),
         builder: (BuildContext context, AsyncSnapshot<List<User>> snapshot) {
           if (snapshot.connectionState == ConnectionState.waiting) {
-            return Expanded(
-              child: Center(
-                child: CircularProgressIndicator(),
-              ),
+            return Center(
+              child: CircularProgressIndicator(),
             );
           } else if (snapshot.hasError) {
             return ErrorPage(refreshFunction: () {

--- a/lib/item_list.dart
+++ b/lib/item_list.dart
@@ -6,8 +6,10 @@ import 'models/item.dart';
 import 'package:intl/intl.dart';
 
 class ItemList extends StatefulWidget {
+  final String onFieldSubmittedText;
   final List<Item> items;
-  ItemList({Key? key, required this.items}) : super(key: key);
+  ItemList({Key? key, required this.items, required this.onFieldSubmittedText})
+      : super(key: key);
   @override
   _ItemListState createState() => _ItemListState();
 }
@@ -15,13 +17,14 @@ class ItemList extends StatefulWidget {
 class _ItemListState extends State<ItemList> {
   final ScrollController _scrollController = ScrollController();
   int _page = 1;
-  String onChangedText = '';
+  bool _isLoading = false;
 
   @override
   void initState() {
     super.initState();
     _scrollController.addListener(() {
-      if (_scrollController.position.pixels == _scrollController.position.maxScrollExtent) {
+      if (_scrollController.position.pixels ==
+          _scrollController.position.maxScrollExtent) {
         fetchMore();
       }
     });
@@ -32,65 +35,72 @@ class _ItemListState extends State<ItemList> {
     return ListView.builder(
       shrinkWrap: true,
       controller: _scrollController,
-        itemCount: widget.items.length,
+      itemCount: widget.items.length,
       itemBuilder: (context, index) {
-                    DateFormat format = DateFormat('yyyy/MM/dd');
-                    String date = format.format(DateTime.parse(widget.items[index].createdAt).toLocal());
-                    return Card(
-                      elevation: 0,
-                      margin: EdgeInsets.all(0),
-                      child: Column(
-                        children: [
-                          ListTile(
-                            leading: CircleAvatar(
-                          backgroundImage: NetworkImage(widget.items[index].user.profileImageUrl),
-                              radius: 19,
-                      ),
-                            title: Text(widget.items[index].title,
-                              maxLines: 2,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                            subtitle: Text('@${widget.items[index].user.id} 投稿日: $date LGTM: ${widget.items[index].likesCount}',
+        DateFormat format = DateFormat('yyyy/MM/dd');
+        String date = format
+            .format(DateTime.parse(widget.items[index].createdAt).toLocal());
+        return Card(
+          elevation: 0,
+          margin: EdgeInsets.all(0),
+          child: Column(
+            children: [
+              ListTile(
+                leading: CircleAvatar(
+                  backgroundImage:
+                      NetworkImage(widget.items[index].user.profileImageUrl),
+                  radius: 19,
+                ),
+                title: Text(
+                  widget.items[index].title,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                subtitle: Text(
+                    '@${widget.items[index].user.id} 投稿日: $date LGTM: ${widget.items[index].likesCount}',
                     maxLines: 2),
-                            onTap: () {
-                              showModalBottomSheet<Item>(
-                                  enableDrag: true,
-                                  backgroundColor: Colors.transparent,
-                                  context: context,
-                                  isScrollControlled: true,
-                                  builder: (BuildContext context) {
-                                    return Container(
-                                        height: 700,
-                                        decoration: BoxDecoration(
-                                            borderRadius: BorderRadius.only(
-                                              topRight: Radius.circular(20),
-                                              topLeft: Radius.circular(20),
-                                            )
-                                        ),
-                                        child: ArticlePage(item: widget.items[index])
-                                    );
-                                  }
-                              );
-                            },
-                          ),
-                          Divider(
-                                indent: 72,
-                                height: 5,
-                                thickness: 0.5,
-                                color: Color(0xFFB2B2B2),
-                              ),
-                        ],
-                      ),
-                    );
-                  },
-              );
+                onTap: () {
+                  showModalBottomSheet<Item>(
+                      enableDrag: true,
+                      backgroundColor: Colors.transparent,
+                      context: context,
+                      isScrollControlled: true,
+                      builder: (BuildContext context) {
+                        return Container(
+                            height: MediaQuery.of(context).size.height * 0.95,
+                            decoration: BoxDecoration(
+                                borderRadius: BorderRadius.only(
+                              topRight: Radius.circular(20),
+                              topLeft: Radius.circular(20),
+                            )),
+                            child: ArticlePage(item: widget.items[index]));
+                      });
+                },
+              ),
+              Divider(
+                indent: 72,
+                height: 5,
+                thickness: 0.5,
+                color: Color(0xFFB2B2B2),
+              ),
+            ],
+          ),
+        );
+      },
+    );
   }
+
   fetchMore() async {
-    _page++;
-     var items = await QiitaRepository.fetchItems(_page, onChangedText);
-     print(items);
-     setState(() {
-       widget.items.addAll(items);
-     });
+    if (!_isLoading) {
+      _isLoading = true;
+      _page++;
+      var items =
+          await QiitaRepository.fetchItems(_page, widget.onFieldSubmittedText);
+      print(items);
+      setState(() {
+        widget.items.addAll(items);
+      });
+      _isLoading = false;
+    }
   }
 }

--- a/lib/login.dart
+++ b/lib/login.dart
@@ -1,5 +1,7 @@
 import 'dart:math';
 
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'qiita_repository.dart';
 import 'package:webview_flutter/webview_flutter.dart';
@@ -14,10 +16,9 @@ class Login extends StatefulWidget {
 
 class _LoginState extends State<Login> {
   final QiitaRepository repository = QiitaRepository();
-
+  bool _isLoading = false;
   String? _state;
   late final Uri uri;
-  bool _isLoading = false;
 
   @override
   void initState() {
@@ -41,24 +42,26 @@ class _LoginState extends State<Login> {
         centerTitle: true,
       ),
       body: WebView(
-        initialUrl: QiitaRepository.createdAuthorizeUrl(_state!),
-        javascriptMode: JavascriptMode.unrestricted,
-        onPageStarted: (String url) {
-          setState(() {
-            _isLoading = true;
-          });
-        },
-        onPageFinished: (String url) {
-          setState(() async {
-            _isLoading = false;
-            print(url);
-            final uri = Uri.parse(url);
-            if (uri.queryParameters['code'] != null) {
-              _onAuthorizeCallbackIsCalled(uri);
-            }
-          });
-        },
-      ),
+          initialUrl: QiitaRepository.createdAuthorizeUrl(_state!),
+          javascriptMode: JavascriptMode.unrestricted,
+          onPageStarted: (String url) {
+            setState(() {
+              _isLoading = true;
+            });
+          },
+          onPageFinished: (String url) {
+            setState(() async {
+              _isLoading = false;
+              print(url);
+              final uri = Uri.parse(url);
+              if (uri.queryParameters['code'] != null) {
+                _onAuthorizeCallbackIsCalled(uri);
+              }
+            });
+          },
+          gestureRecognizers: Set()
+            ..add(Factory<OneSequenceGestureRecognizer>(
+                () => EagerGestureRecognizer()))),
     );
   }
 

--- a/lib/my_page.dart
+++ b/lib/my_page.dart
@@ -16,10 +16,15 @@ class MyPage extends StatefulWidget {
 }
 
 class _MyPageState extends State<MyPage> {
+  int _page = 1;
   var isLogin = false;
+  late Future<User> refreshMyProfile;
+  late Future<List<Item>> refreshMyItemList;
 
   @override
   void initState() {
+    refreshMyProfile = QiitaRepository.fetchAuthenticatedUser();
+    refreshMyItemList = QiitaRepository.fetchAuthenticatedUserItem(_page);
     super.initState();
 
     QiitaRepository.accessTokenIsSaved().then((isSaved) {
@@ -35,7 +40,7 @@ class _MyPageState extends State<MyPage> {
         ConstrainedBox(
           constraints: BoxConstraints(maxHeight: 256.0),
           child: FutureBuilder<User>(
-            future: QiitaRepository.fetchAuthenticatedUser(),
+            future: refreshMyProfile,
             builder: (BuildContext context, AsyncSnapshot<User> snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
                 return Expanded(
@@ -45,10 +50,17 @@ class _MyPageState extends State<MyPage> {
                 );
               } else if (snapshot.hasError) {
                 return ErrorPage(refreshFunction: () {
-                  QiitaRepository.fetchAuthenticatedUser();
+                  refreshMyProfile = QiitaRepository.fetchAuthenticatedUser();
                 });
               } else {
-                return MyPageUserDetail(userData: snapshot.data);
+                return RefreshIndicator(
+                    child: MyPageUserDetail(userData: snapshot.data),
+                    onRefresh: () async {
+                      setState(() {
+                        refreshMyProfile =
+                            QiitaRepository.fetchAuthenticatedUser();
+                      });
+                    });
               }
             },
           ),
@@ -78,7 +90,7 @@ class _MyPageState extends State<MyPage> {
         ),
         Expanded(
           child: FutureBuilder<List<Item>>(
-            future: QiitaRepository.fetchAuthenticatedUserItem(),
+            future: refreshMyItemList,
             builder:
                 (BuildContext context, AsyncSnapshot<List<Item>> snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
@@ -90,11 +102,20 @@ class _MyPageState extends State<MyPage> {
               } else if (snapshot.hasError) {
                 return ErrorPage(
                   refreshFunction: () {
-                    QiitaRepository.fetchAuthenticatedUserItem();
+                    refreshMyItemList =
+                        QiitaRepository.fetchAuthenticatedUserItem(_page);
                   },
                 );
               } else {
-                return MyPageItemList(itemData: snapshot.data!);
+                return RefreshIndicator(
+                  child: MyPageItemList(itemData: snapshot.data!),
+                  onRefresh: () async {
+                    setState(() {
+                      refreshMyItemList =
+                          QiitaRepository.fetchAuthenticatedUserItem(_page);
+                    });
+                  },
+                );
               }
             },
           ),
@@ -166,6 +187,7 @@ class _MyPageState extends State<MyPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        elevation: 0,
         backgroundColor: Constants.white,
         title: Text(
           'MyPage',
@@ -176,6 +198,14 @@ class _MyPageState extends State<MyPage> {
           ),
         ),
         centerTitle: true,
+        bottom: PreferredSize(
+          preferredSize: Size.fromHeight(0),
+          child: Divider(
+            height: 0,
+            thickness: 0.5,
+            color: Constants.greyDivider,
+          ),
+        ),
       ),
       body: isLogin ? loginUI() : notLoginUI(),
     );

--- a/lib/my_page.dart
+++ b/lib/my_page.dart
@@ -94,10 +94,8 @@ class _MyPageState extends State<MyPage> {
             builder:
                 (BuildContext context, AsyncSnapshot<List<Item>> snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
-                return Expanded(
-                  child: Center(
-                    child: CircularProgressIndicator(),
-                  ),
+                return Center(
+                  child: CircularProgressIndicator(),
                 );
               } else if (snapshot.hasError) {
                 return ErrorPage(

--- a/lib/my_page_item_list.dart
+++ b/lib/my_page_item_list.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mobile_qiita_application/qiita_repository.dart';
 import 'article_page.dart';
 import 'models/item.dart';
 import 'package:intl/intl.dart';
@@ -11,27 +12,45 @@ class MyPageItemList extends StatefulWidget {
 }
 
 class _MyPageItemListState extends State<MyPageItemList> {
+  int _page = 1;
+  bool _isLoading = false;
+  ScrollController _scrollController = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(() {
+      if (_scrollController.position.pixels ==
+          _scrollController.position.maxScrollExtent) {
+        fetchMore();
+      }
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return ListView.builder(
-      shrinkWrap: true,
-      itemCount: widget.itemData.length,
+        controller: _scrollController,
+        shrinkWrap: true,
+        itemCount: widget.itemData.length,
         itemBuilder: (BuildContext context, int index) {
           DateFormat format = DateFormat('yyyy/MM/dd');
-          String date = format.format(DateTime.parse(widget.itemData[index].createdAt).toLocal());
+          String date = format.format(
+              DateTime.parse(widget.itemData[index].createdAt).toLocal());
           return Card(
             elevation: 0,
             margin: EdgeInsets.all(0),
             child: Column(
               children: [
                 ListTile(
-                  title: Text(widget.itemData[index].title,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
+                  title: Text(
+                    widget.itemData[index].title,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
                   ),
-                  subtitle: Text('@${widget.itemData[index].user.id} 投稿日: $date LGTM: ${widget.itemData[index].likesCount}',
-                  maxLines: 2,
+                  subtitle: Text(
+                    '@${widget.itemData[index].user.id} 投稿日: $date LGTM: ${widget.itemData[index].likesCount}',
+                    maxLines: 2,
                   ),
                   onTap: () {
                     showModalBottomSheet<Item>(
@@ -44,14 +63,11 @@ class _MyPageItemListState extends State<MyPageItemList> {
                               height: MediaQuery.of(context).size.height * 0.95,
                               decoration: BoxDecoration(
                                   borderRadius: BorderRadius.only(
-                                    topRight: Radius.circular(20),
-                                    topLeft: Radius.circular(20),
-                                  )
-                              ),
-                              child: ArticlePage(item: widget.itemData[index])
-                          );
-                        }
-                    );
+                                topRight: Radius.circular(20),
+                                topLeft: Radius.circular(20),
+                              )),
+                              child: ArticlePage(item: widget.itemData[index]));
+                        });
                   },
                 ),
                 Divider(
@@ -64,5 +80,18 @@ class _MyPageItemListState extends State<MyPageItemList> {
             ),
           );
         });
+  }
+
+  fetchMore() async {
+    if (!_isLoading) {
+      _isLoading = true;
+      _page++;
+      var myItemList = await QiitaRepository.fetchAuthenticatedUserItem(_page);
+      print(myItemList);
+      setState(() {
+        widget.itemData.addAll(myItemList);
+      });
+      _isLoading = false;
+    }
   }
 }

--- a/lib/my_page_user_detail.dart
+++ b/lib/my_page_user_detail.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_qiita_application/constants.dart';
-import 'package:mobile_qiita_application/followers_page.dart';
-import 'package:mobile_qiita_application/follows_page.dart';
+import 'package:mobile_qiita_application/follow_follower_page.dart';
 import 'package:mobile_qiita_application/models/user.dart';
 
 class MyPageUserDetail extends StatefulWidget {
@@ -57,63 +56,67 @@ class _MyPageUserDetailState extends State<MyPageUserDetail> {
           const SizedBox(height: 16),
           Row(
             children: [
-              Builder(
-                builder: (context) => InkWell(
-                  onTap: () {
+              InkWell(
+                onTap: () {
+                  if (widget.userData!.followeesCount != 0) {
                     Navigator.push(
                         context,
                         MaterialPageRoute(
-                            builder: (_) =>
-                                FollowsPage(userData: widget.userData!)));
-                  },
-                  child: Text(
-                    '${widget.userData!.followeesCount}',
-                    style: TextStyle(
-                      fontSize: 12,
-                      fontWeight: FontWeight.w700,
-                      color: Constants.black,
-                    ),
-                  ),
-                ),
-              ),
-              const SizedBox(width: 5),
-              Text(
-                'フォロー中',
-                style: TextStyle(
-                  fontSize: 12,
-                  color: Constants.grey,
+                            builder: (_) => FollowFollowerPage(
+                                userData: widget.userData!,
+                                followeesTapped: true)));
+                  }
+                },
+                child: RichText(
+                  text: TextSpan(children: [
+                    TextSpan(
+                        text: '${widget.userData!.followeesCount}',
+                        style: TextStyle(
+                          fontWeight: FontWeight.w700,
+                          fontSize: 12,
+                          color: Constants.black,
+                        )),
+                    TextSpan(
+                        text: ' フォロー中',
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: Constants.grey,
+                        )),
+                  ]),
                 ),
               ),
               const SizedBox(width: 8),
-              Builder(
-                builder: (context) => InkWell(
-                  onTap: () {
+              InkWell(
+                onTap: () {
+                  if (widget.userData!.followersCount != 0) {
                     Navigator.push(
                         context,
                         MaterialPageRoute(
-                            builder: (_) =>
-                                FollowersPage(userData: widget.userData!)));
-                  },
-                  child: Text(
-                    '${widget.userData!.followersCount}',
+                            builder: (_) => FollowFollowerPage(
+                                userData: widget.userData!,
+                                followeesTapped: false)));
+                  }
+                },
+                child: RichText(
+                    text: TextSpan(children: [
+                  TextSpan(
+                    text: '${widget.userData!.followersCount}',
                     style: TextStyle(
                       fontSize: 12,
                       fontWeight: FontWeight.w700,
                       color: Constants.black,
                     ),
                   ),
-                ),
-              ),
-              const SizedBox(width: 5),
-              Text(
-                'フォロワー',
-                style: TextStyle(
-                  fontSize: 12,
-                  color: Constants.black,
-                ),
+                  TextSpan(
+                      text: ' フォロワー',
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: Constants.black,
+                      ))
+                ])),
               )
             ],
-          ),
+          )
         ],
       ),
     );

--- a/lib/qiita_repository.dart
+++ b/lib/qiita_repository.dart
@@ -11,8 +11,8 @@ import 'models/tags.dart';
 import 'models/user.dart';
 
 class QiitaRepository {
-  static final clientID = '${Client().clientId}';
-  static final clientSecret = '${Client().clientSecret}';
+  static final clientID = '${Client.clientId}';
+  static final clientSecret = '${Client.clientSecret}';
   static final keyAccessToken = 'qiita/accessToken';
 
   Future<String> getVersionNumber() async {
@@ -51,7 +51,7 @@ class QiitaRepository {
   }
 
   static String createdAuthorizeUrl(String state) {
-    final scope = 'read_qiita write_qiita';
+    final scope = 'read_qiita%20write_qiita';
     return 'https://qiita.com/api/v2/oauth/authorize?client_id=$clientID&scope=$scope&state=$state';
   }
 
@@ -96,11 +96,11 @@ class QiitaRepository {
     }
   }
 
-  static Future<List<Item>> fetchAuthenticatedUserItem() async {
+  static Future<List<Item>> fetchAuthenticatedUserItem(int page) async {
     final accessToken = await getAccessToken();
     final response = await http.get(
       Uri.parse(
-          'https://qiita.com/api/v2/authenticated_user/items?page=1&per_page=20'),
+          'https://qiita.com/api/v2/authenticated_user/items?page=$page&per_page=20'),
       headers: {
         'Authorization': 'Bearer $accessToken',
       },

--- a/lib/tag_detail_page.dart
+++ b/lib/tag_detail_page.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_qiita_application/error_page.dart';
-import 'package:mobile_qiita_application/item_list.dart';
 import 'package:mobile_qiita_application/models/item.dart';
 import 'package:mobile_qiita_application/qiita_repository.dart';
 import 'package:mobile_qiita_application/tag_detail_item_list.dart';
-
 
 class tagDetailPage extends StatefulWidget {
   final String tagId;
@@ -21,6 +19,7 @@ class _tagDetailPageState extends State<tagDetailPage> {
     refreshItems = QiitaRepository.fetchArticle(_page, widget.tagId);
     super.initState();
   }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -34,11 +33,12 @@ class _tagDetailPageState extends State<tagDetailPage> {
             Navigator.of(context).pop();
           },
         ),
-        title: Text(widget.tagId,
-        style: TextStyle(
-          fontSize: 17,
-          color: Color(0xFF000000),
-        ),
+        title: Text(
+          widget.tagId,
+          style: TextStyle(
+            fontSize: 17,
+            color: Color(0xFF000000),
+          ),
         ),
         centerTitle: true,
         bottom: PreferredSize(
@@ -49,11 +49,12 @@ class _tagDetailPageState extends State<tagDetailPage> {
               children: [
                 Padding(
                   padding: EdgeInsets.only(left: 12, top: 8.5, bottom: 7.5),
-                  child: Text('投稿記事',
-                  style: TextStyle(
-                    fontSize: 12,
-                    color: Color(0xFF828282),
-                  ),
+                  child: Text(
+                    '投稿記事',
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: Color(0xFF828282),
+                    ),
                   ),
                 ),
                 Expanded(child: Container())
@@ -63,37 +64,31 @@ class _tagDetailPageState extends State<tagDetailPage> {
         ),
       ),
       body: Center(
-        child: Column(
-          children: [
-            FutureBuilder<List<Item>>(
-                future: refreshItems,
-                builder: (BuildContext context, AsyncSnapshot<List<Item>> snapshot) {
-                  if (snapshot.connectionState == ConnectionState.waiting) {
-                    return Expanded(
-                        child: Center(
-                          child: CircularProgressIndicator(),
-                        )
-                    );
-                  } else if (snapshot.hasError){
-                    return ErrorPage(
-                      refreshFunction: () {
-                        refreshItems = QiitaRepository.fetchArticle(_page, widget.tagId);
+          child: FutureBuilder<List<Item>>(
+              future: refreshItems,
+              builder:
+                  (BuildContext context, AsyncSnapshot<List<Item>> snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return CircularProgressIndicator();
+                } else if (snapshot.hasError) {
+                  return ErrorPage(
+                    refreshFunction: () {
+                      refreshItems =
+                          QiitaRepository.fetchArticle(_page, widget.tagId);
+                    },
+                  );
+                } else {
+                  return Expanded(
+                    child: RefreshIndicator(
+                      onRefresh: () async {
+                        QiitaRepository.fetchArticle(_page, widget.tagId);
                       },
-                    );
-                  } else {
-                    return Expanded(
-                        child: RefreshIndicator(
-                          onRefresh: () async {
-                            QiitaRepository.fetchArticle(_page, widget.tagId);
-                          },
-                            child: TagDetailItemList(itemList: snapshot.data!, tagID: widget.tagId),
-                        ),
-                    );
-                  }
-                })
-          ],
-        ),
-      ),
+                      child: TagDetailItemList(
+                          itemList: snapshot.data!, tagID: widget.tagId),
+                    ),
+                  );
+                }
+              })),
     );
   }
 }

--- a/lib/tag_list.dart
+++ b/lib/tag_list.dart
@@ -19,7 +19,8 @@ class _TagListState extends State<TagList> {
   void initState() {
     super.initState();
     _scrollController.addListener(() {
-      if (_scrollController.position.pixels == _scrollController.position.maxScrollExtent) {
+      if (_scrollController.position.pixels ==
+          _scrollController.position.maxScrollExtent) {
         fetchTagsMore();
       }
     });
@@ -28,67 +29,70 @@ class _TagListState extends State<TagList> {
   @override
   Widget build(BuildContext context) {
     return Expanded(
-        child: GridView.builder(
-          controller: _scrollController,
-          gridDelegate:  SliverGridDelegateWithMaxCrossAxisExtent(
-            maxCrossAxisExtent: 210,
-            mainAxisExtent: 155,
-            childAspectRatio: 1.28,
-          ),
-          itemCount: widget.tags.length,
-          itemBuilder: (BuildContext context, int index) {
-            return Container(
-              padding: EdgeInsets.only(left: 8, right: 8, top: 16),
-                child: Material(
-                borderRadius: BorderRadius.all(Radius.circular(8)),
-                child: InkWell(
-                  onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(builder: (_) => tagDetailPage(tagId: widget.tags[index].id))
-                    );
-              },
-                  child: Container(
-                          alignment: Alignment.center,
-                          child: Column(
-                            children: [
-                              SizedBox(height: 16),
-                              Image.network(widget.tags[index].iconUrl),
-                              SizedBox(height: 8),
-                              Text(widget.tags[index].id,
-                              style: TextStyle(
-                                fontSize: 14,
-                                color: Color(0xFF333333),
-                              ),
-                              ),
-                              SizedBox(height: 8),
-                              Text('記事件数: ${widget.tags[index].itemsCount}',
-                              style: TextStyle(
-                                fontSize: 12,
-                                color: Color(0xFF828282),
-                              ),
-                              ),
-                              SizedBox(height: 8),
-                              Text('フォロワー数: ${widget.tags[index].followersCount}',
-                              style: TextStyle(
-                                fontSize: 12,
-                                color: Color(0xFF828282),
-                              ),
-                              ),
-                            ],
-                          ),
-                          decoration: BoxDecoration(
-                            color: Color(0xFFFFFFFF),
-                            borderRadius: BorderRadius.circular(8),
-                            border: Border.all(color: Color(0xFFE0E0E0), width: 1)
-                          ),
-                        ),
-                  ),
-                  ),
-                  );
-          },
+      child: GridView.builder(
+        shrinkWrap: true,
+        controller: _scrollController,
+        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 2,
+          childAspectRatio: 1.28,
         ),
-      );
+        itemCount: widget.tags.length,
+        itemBuilder: (BuildContext context, int index) {
+          return Container(
+            padding: EdgeInsets.only(left: 8, right: 8, top: 16),
+            child: Material(
+              borderRadius: BorderRadius.all(Radius.circular(8)),
+              child: InkWell(
+                onTap: () {
+                  Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (_) =>
+                              tagDetailPage(tagId: widget.tags[index].id)));
+                },
+                child: Container(
+                  alignment: Alignment.center,
+                  child: Column(
+                    children: [
+                      SizedBox(height: 16),
+                      Image.network(widget.tags[index].iconUrl),
+                      SizedBox(height: 8),
+                      Text(
+                        widget.tags[index].id,
+                        style: TextStyle(
+                          fontSize: 14,
+                          color: Color(0xFF333333),
+                        ),
+                      ),
+                      SizedBox(height: 8),
+                      Text(
+                        '記事件数: ${widget.tags[index].itemsCount}',
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: Color(0xFF828282),
+                        ),
+                      ),
+                      SizedBox(height: 8),
+                      Text(
+                        'フォロワー数: ${widget.tags[index].followersCount}',
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: Color(0xFF828282),
+                        ),
+                      ),
+                    ],
+                  ),
+                  decoration: BoxDecoration(
+                      color: Color(0xFFFFFFFF),
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(color: Color(0xFFE0E0E0), width: 1)),
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
   }
 
   fetchTagsMore() async {

--- a/lib/tag_page.dart
+++ b/lib/tag_page.dart
@@ -1,6 +1,6 @@
-import 'package:custom_refresh_indicator/custom_refresh_indicator.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:mobile_qiita_application/constants.dart';
 import 'package:mobile_qiita_application/error_page.dart';
 import 'package:mobile_qiita_application/tag_list.dart';
 import 'package:mobile_qiita_application/models/tags.dart';
@@ -12,10 +12,7 @@ class TagPage extends StatefulWidget {
 }
 
 class _TagPageState extends State<TagPage> {
-  QiitaRepository qiitaRepository = QiitaRepository();
   int _page = 1;
-  List<Tags> tagList = [];
-  bool isLoading = false;
   late Future<List<Tags>> refreshTags;
 
   @override
@@ -23,13 +20,16 @@ class _TagPageState extends State<TagPage> {
     refreshTags = QiitaRepository.fetchTags(_page);
     super.initState();
   }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        elevation: 0,
         toolbarHeight: 45,
         backgroundColor: Colors.white,
-        title: Text('Tags',
+        title: Text(
+          'Tags',
           style: TextStyle(
             fontSize: 17,
             fontFamily: 'Pacifico',
@@ -37,86 +37,45 @@ class _TagPageState extends State<TagPage> {
           ),
         ),
         centerTitle: true,
+        bottom: PreferredSize(
+          preferredSize: Size.fromHeight(0),
+          child: Divider(
+            height: 0,
+            thickness: 0.5,
+            color: Constants.greyDivider,
+          ),
+        ),
       ),
       body: Container(
         color: Color(0xFFFFFFFF),
         child: Center(
-          child: Column(
-            children: [
-              FutureBuilder(
-                  future: refreshTags,
-                  builder: (BuildContext context, AsyncSnapshot<List<Tags>> snapshot) {
-                    if (snapshot.connectionState == ConnectionState.waiting) {
-                      return Expanded(
-                          child: Center(
-                            child: CircularProgressIndicator(),
-                          )
-                      );
-                    } else if (snapshot.hasError) {
-                      return ErrorPage(
-                        refreshFunction: () {
+            child: FutureBuilder(
+                future: refreshTags,
+                builder:
+                    (BuildContext context, AsyncSnapshot<List<Tags>> snapshot) {
+                  if (snapshot.connectionState == ConnectionState.waiting) {
+                    return Expanded(
+                        child: Center(
+                      child: CircularProgressIndicator(),
+                    ));
+                  } else if (snapshot.hasError) {
+                    return ErrorPage(
+                      refreshFunction: () {
+                        refreshTags = QiitaRepository.fetchTags(_page);
+                      },
+                    );
+                  } else {
+                    return RefreshIndicator(
+                      onRefresh: () async {
+                        setState(() {
                           refreshTags = QiitaRepository.fetchTags(_page);
-                        },
-                      );
-                    } else {
-                      return Expanded(
-                          child: CustomRefreshIndicator(
-                            onRefresh: () async {
-                              if (!isLoading) {
-                                isLoading = true;
-                                fetchTagsRefresh();
-                                isLoading = false;
-                              }
-                            },
-                            child: TagList(tags: snapshot.data!),
-                            builder: (
-                                BuildContext context,
-                                Widget child,
-                                IndicatorController controller,
-                                ) {
-                              return AnimatedBuilder(
-                                  animation: controller,
-                                  builder: (BuildContext context, _) {
-                                    return Stack(
-                                      alignment: Alignment.topCenter,
-                                      children: [
-                                        if(!controller.isIdle)
-                                          Positioned(
-                                            top: 35.0 * controller.value,
-                                            child: SizedBox(
-                                              height: 30,
-                                              width: 30,
-                                              child: CircularProgressIndicator(
-                                                value: !controller.isLoading
-                                                    ? controller.value.clamp(0.0, 1.0)
-                                                    : null,
-                                              ),
-                                            ),
-                                          ),
-                                        Transform.translate(
-                                          offset: Offset(0, 100.0 * controller.value),
-                                          child: child,
-                                        )
-                                      ],
-                                    );
-                                  });
-                            },
-                          ));
-                    }
-                  })
-            ],
-          ),
-        ),
+                        });
+                      },
+                      child: TagList(tags: snapshot.data!),
+                    );
+                  }
+                })),
       ),
     );
-  }
-
-  fetchTagsRefresh() async {
-      _page = 1;
-      var tags = await QiitaRepository.fetchTags(_page);
-      print(tags);
-      setState(() {
-        tagList.addAll(tags);
-      });
   }
 }

--- a/lib/tag_page.dart
+++ b/lib/tag_page.dart
@@ -54,10 +54,7 @@ class _TagPageState extends State<TagPage> {
                 builder:
                     (BuildContext context, AsyncSnapshot<List<Tags>> snapshot) {
                   if (snapshot.connectionState == ConnectionState.waiting) {
-                    return Expanded(
-                        child: Center(
-                      child: CircularProgressIndicator(),
-                    ));
+                    return CircularProgressIndicator();
                   } else if (snapshot.hasError) {
                     return ErrorPage(
                       refreshFunction: () {

--- a/lib/user_detail.dart
+++ b/lib/user_detail.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_qiita_application/constants.dart';
-import 'package:mobile_qiita_application/followers_page.dart';
-import 'package:mobile_qiita_application/follows_page.dart';
+import 'package:mobile_qiita_application/follow_follower_page.dart';
 import 'package:mobile_qiita_application/models/user.dart';
 
 class UserDetail extends StatefulWidget {
@@ -65,56 +64,63 @@ class _UserDetailState extends State<UserDetail> {
             children: [
               InkWell(
                 onTap: () {
-                  Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                          builder: (_) =>
-                              FollowsPage(userData: widget.userData)));
+                  if (widget.userData.followeesCount != 0) {
+                    Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            builder: (_) => FollowFollowerPage(
+                                userData: widget.userData,
+                                followeesTapped: true)));
+                  }
                 },
-                child: Text(
-                  '${widget.userData.followeesCount}',
-                  style: TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.w700,
-                    color: Constants.black,
-                  ),
-                ),
-              ),
-              const SizedBox(width: 5),
-              Text(
-                'フォロー中',
-                style: TextStyle(
-                  fontSize: 12,
-                  color: Constants.grey,
+                child: RichText(
+                  text: TextSpan(children: [
+                    TextSpan(
+                        text: '${widget.userData.followeesCount}',
+                        style: TextStyle(
+                          fontWeight: FontWeight.w700,
+                          fontSize: 12,
+                          color: Constants.black,
+                        )),
+                    TextSpan(
+                        text: ' フォロー中',
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: Constants.grey,
+                        )),
+                  ]),
                 ),
               ),
               const SizedBox(width: 8),
               InkWell(
                 onTap: () {
-                  Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) =>
-                            FollowersPage(userData: widget.userData),
-                      ));
+                  if (widget.userData.followersCount != 0) {
+                    Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            builder: (_) => FollowFollowerPage(
+                                userData: widget.userData,
+                                followeesTapped: false)));
+                  }
                 },
-                child: Text(
-                  '${widget.userData.followersCount}',
-                  style: TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.w700,
-                    color: Constants.black,
+                child: RichText(
+                    text: TextSpan(children: [
+                  TextSpan(
+                    text: '${widget.userData.followersCount}',
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                      color: Constants.black,
+                    ),
                   ),
-                ),
-              ),
-              const SizedBox(width: 5),
-              Text(
-                'フォロワー',
-                style: TextStyle(
-                  fontSize: 12,
-                  color: Constants.black,
-                ),
-              ),
+                  TextSpan(
+                      text: ' フォロワー',
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: Constants.black,
+                      ))
+                ])),
+              )
             ],
           )
         ],

--- a/lib/user_page.dart
+++ b/lib/user_page.dart
@@ -117,10 +117,8 @@ class _UserPageState extends State<UserPage> {
             builder:
                 (BuildContext context, AsyncSnapshot<List<Item>> snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
-                return Expanded(
-                  child: Center(
-                    child: CircularProgressIndicator(),
-                  ),
+                return Center(
+                  child: CircularProgressIndicator(),
                 );
               } else if (snapshot.hasError) {
                 return ErrorPage(refreshFunction: () {

--- a/lib/user_page.dart
+++ b/lib/user_page.dart
@@ -17,6 +17,15 @@ class UserPage extends StatefulWidget {
 
 class _UserPageState extends State<UserPage> {
   int _page = 1;
+  late Future<User> refreshUser;
+  late Future<List<Item>> refreshUserItem;
+
+  @override
+  void initState() {
+    refreshUser = QiitaRepository.fetchUsers(widget.userData.id);
+    refreshUserItem = QiitaRepository.fetchUserItems(widget.userData.id, _page);
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -54,7 +63,7 @@ class _UserPageState extends State<UserPage> {
       body: Column(
         children: [
           FutureBuilder<User>(
-            future: QiitaRepository.fetchUsers(widget.userData.id),
+            future: refreshUser,
             builder: (BuildContext context, AsyncSnapshot<User> snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
                 return Expanded(
@@ -64,10 +73,18 @@ class _UserPageState extends State<UserPage> {
                 );
               } else if (snapshot.hasError) {
                 return ErrorPage(refreshFunction: () {
-                  QiitaRepository.fetchUsers(widget.userData.id);
+                  refreshUser = QiitaRepository.fetchUsers(widget.userData.id);
                 });
               } else {
-                return UserDetail(userData: snapshot.data!);
+                return RefreshIndicator(
+                  child: UserDetail(userData: snapshot.data!),
+                  onRefresh: () async {
+                    setState(() {
+                      refreshUser =
+                          QiitaRepository.fetchUsers(widget.userData.id);
+                    });
+                  },
+                );
               }
             },
           ),
@@ -96,7 +113,7 @@ class _UserPageState extends State<UserPage> {
           ),
           Expanded(
               child: FutureBuilder<List<Item>>(
-            future: QiitaRepository.fetchUserItems(widget.userData.id, _page),
+            future: refreshUserItem,
             builder:
                 (BuildContext context, AsyncSnapshot<List<Item>> snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
@@ -107,11 +124,20 @@ class _UserPageState extends State<UserPage> {
                 );
               } else if (snapshot.hasError) {
                 return ErrorPage(refreshFunction: () {
-                  QiitaRepository.fetchUserItems(widget.userData.id, _page);
+                  refreshUserItem =
+                      QiitaRepository.fetchUserItems(widget.userData.id, _page);
                 });
               } else {
-                return UserItem(
-                    userItem: snapshot.data!, userData: widget.userData);
+                return RefreshIndicator(
+                  onRefresh: () async {
+                    setState(() {
+                      refreshUserItem = QiitaRepository.fetchUserItems(
+                          widget.userData.id, _page);
+                    });
+                  },
+                  child: UserItem(
+                      userItem: snapshot.data!, userData: widget.userData),
+                );
               }
             },
           ))


### PR DESCRIPTION
### 概要
テストでおかしかった点を修正したり、足りない機能を実装しました！
[566291f](https://github.com/shinonome-inc/mobile_Koshi/pull/26/commits/566291f2ba27e59db7f2ad15ff9a39c9522d4754)
### 修正や実装した内容

- OauthWebPage：ユーザー名またはメールアドレスまたはパスワードをタップ時に入力部が隠れないように、WebView内のスクロールを実装。
- FeedPage：キーボード表示中にtableViewをスクロールしたときにキーボードが隠れる機能の実装。
- FeedPage：検索結果0件時のViewを表示する機能の実装。
- FeedPage：回数制限のエラー画面に遷移する機能を実装。
- ArticlePage：モーダルの高さをデバイスの高さを取得して設定。
- TagPage：Pull to refresh機能を実装。
- MyPage、UserPage：フォローフォロワー数の表示のUIの修正。
- MyPage、UserPage：フォロー数(フォロワー数)が0の時はボタンを押しても反応しない機能を実装。
- MyPage：投稿記事の無限スクロールを実装。
- MyPage：Pull to refresh機能を実装。
- FollowFollowerPage：segmented controlを追加。
- FollowFollowerPage：フォロー中(フォロワー)を押されて遷移してきた時にsegmented controlでフォロー中(フォロワー)が選択されている機能を実装。
- FollowFollowerPage：フォロー中(フォロワー)を選択中にフォロー(フォロワー)リストが表示される機能を実装。
- FollowFollowerPage：segmented controlで非選択状態の要素をタップしたときにデータが更新される機能を実装。
- UserPage：Pull to refresh機能を実装。